### PR TITLE
Remove imagedisplaydialog.h include

### DIFF
--- a/src/tetherwindow.cpp
+++ b/src/tetherwindow.cpp
@@ -2,7 +2,6 @@
 #include "ui_tetherwindow.h"
 #include <libexif/exif-loader.h>
 #include "tetherthumb.h"
-#include "imagedisplaydialog.h"
 #include <QDebug>
 #include <map>
 #include <iostream>


### PR DESCRIPTION
Remove imagedisplaydialog.h include that was left over from a long time ago?

Don't know why it's there, but removing it lets it build.
